### PR TITLE
Let `--add-git-submodule` do nothing in case the submodule is already installed in “modules” directory

### DIFF
--- a/bin/pmbp.pl
+++ b/bin/pmbp.pl
@@ -1145,12 +1145,13 @@ sub git_submodule_url ($$) {
 sub add_git_submodule ($$;%);
 sub add_git_submodule ($$;%) {
   my ($git_dir_name, $url, %args) = @_;
+  my $default_parent = 'modules';
   my $parent = $args{parent_dir_name};
-  $parent = 'modules' if not defined $parent;
+  $parent = $default_parent if not defined $parent;
   my $dir_name = [grep { length } split m{/}, $url]->[-1];
   $dir_name =~ s/\.git$//;
   $dir_name =~ s/^perl-//;
-  for my $submodule (grep { $_->{dir_name} =~ m{^\Q$parent\E/} } @{git_submodules $git_dir_name}) {
+  for my $submodule (grep { $_->{dir_name} =~ m{^(?:\Q$parent\E|\Q$default_parent\E)/} } @{git_submodules $git_dir_name}) {
     if ($submodule->{url} eq $url) {
       info 5, "$git_dir_name: submodule <$url> is already added as |$submodule->{dir_name}|";
       if ($args{recursive} and $args{top_level}) {
@@ -6364,7 +6365,8 @@ there must be no trailing slash (C</>) character in the container
 directory path.
 
 If there is already a Git submodule with the specified URL as a child
-of the container directory, this command does nothing.
+of the container directory or as a child of C<modules> directory,
+this command does nothing.
 
 Otherwise, the specified Git repository is added as a child of the
 container directory, whose directory name is the last path segment of
@@ -6380,8 +6382,8 @@ For example,
 
   $ perl local/bin/pmbp.pl --add-git-submodule "t_deps/modules git://example/my/app1.git"
 
-... will add the Git repository as a submodule C<t_deps/modules/app1>,
-even when there is C<modules/app1>.
+... will add the Git repository as a submodule C<t_deps/modules/app1>.
+(It will do nothing, however, in case that there is C<modules/app1>.)
 
 If the submodule added contains a file
 C<config/perl/pmbp-extra-modules.txt>, its content is merged into the
@@ -6396,6 +6398,10 @@ Add a Git submodule recursively.  That is, this command adds the
 specified Git repository, as well as submodules of the repository in
 the specified container directory (if specified) or the C<modules>
 directory (if not specified).
+
+If there is already a Git submodule which is specified one or its descendant
+as a child of the container directory or as a child of C<modules> directory,
+that submodule will not be installed.
 
 =back
 

--- a/t/pmbp-git/submodule-add-1.t
+++ b/t/pmbp-git/submodule-add-1.t
@@ -1,5 +1,5 @@
 #!/bin/sh
-echo "1..9"
+echo "1..7"
 basedir=$(cd `dirname $0`/../.. && pwd)
 pmbp=$basedir/bin/pmbp.pl
 tempdir=`perl -MFile::Temp=tempdir -e 'print tempdir'`/testapp
@@ -22,8 +22,5 @@ cd $tempdir/hoge/git1 && git init && touch b && git add b && git commit -m new
 (perl $pmbp --root-dir-name $tempdir/foo --add-git-submodule $tempdir/hoge/git1 && echo "ok 5") || echo "not ok 5"
 (cat $tempdir/foo/modules/git1/b && echo "not ok 6") || echo "ok 6"
 (cat $tempdir/foo/modules/git1.2/b && echo "ok 7") || echo "not ok 7"
-
-(perl $pmbp --root-dir-name $tempdir/foo --add-git-submodule aa/m\ $tempdir/git1 && echo "ok 8") || echo "not ok 8"
-(cat $tempdir/foo/aa/m/git1/a && echo "ok 9") || echo "not ok 9"
 
 rm -fr $tempdir

--- a/t/pmbp-git/submodule-add-3-parent-dir.t
+++ b/t/pmbp-git/submodule-add-3-parent-dir.t
@@ -1,0 +1,41 @@
+#!/bin/sh
+echo "1..6"
+basedir=$(cd `dirname $0`/../.. && pwd)
+pmbp=$basedir/bin/pmbp.pl
+tempdir=`perl -MFile::Temp=tempdir -e 'print tempdir'`/testapp
+
+mkdir -p $tempdir/git1
+cd $tempdir/git1 && git init && touch a && git add a && git commit -m new
+
+# Test case 1 : new Git module should be installed into specified container directory
+
+mkdir -p $tempdir/foo
+cd $tempdir/foo && git init
+
+(perl $pmbp --root-dir-name $tempdir/foo --add-git-submodule "t_deps/modules $tempdir/git1" && echo "ok 1") || echo "not ok 1"
+([ -f "$tempdir/foo/t_deps/modules/git1/a" ] && echo "ok 2") || echo "not ok 2"
+
+rm -fr $tempdir/foo
+
+# Test case 2 : in case that specified Git module is already installed in "modules" directory,
+#   new Git module shouldn't be installed in specified container directory
+
+mkdir -p $tempdir/foo
+cd $tempdir/foo && git init
+
+(perl $pmbp --root-dir-name $tempdir/foo --add-git-submodule $tempdir/git1 && echo "ok 3") || echo "not ok 3"
+(perl $pmbp --root-dir-name $tempdir/foo --add-git-submodule "t_deps/modules $tempdir/git1" && echo "ok 4") || echo "not ok 4"
+([ -f "$tempdir/foo/modules/git1/a" ] && echo "ok 5") || echo "not ok 5"
+([ ! -d "$tempdir/foo/t_deps" ] && echo "ok 6") || echo "not ok 6"
+
+rm -fr $tempdir/foo
+
+rm -fr $tempdir
+
+# * LICENSE
+#
+# Copyright 2012-2016 Wakaba <wakaba@suikawiki.org>.
+# Copyright 2017 Hatena <https://www.hatena.ne.jp/company/>.
+#
+# This library is free software; you can redistribute it and/or modify
+# it under the same terms as Perl itself.

--- a/t/pmbp-git/submodule-add-r-1.t
+++ b/t/pmbp-git/submodule-add-r-1.t
@@ -1,5 +1,5 @@
 #!/bin/sh
-echo "1..9"
+echo "1..7"
 basedir=$(cd `dirname $0`/../.. && pwd)
 pmbp=$basedir/bin/pmbp.pl
 tempdir=`perl -MFile::Temp=tempdir -e 'print tempdir'`/testapp
@@ -22,8 +22,5 @@ cd $tempdir/hoge/git1 && git init && touch b && git add b && git commit -m new
 (perl $pmbp --root-dir-name $tempdir/foo --add-git-submodule-recursively $tempdir/hoge/git1 && echo "ok 5") || echo "not ok 5"
 (cat $tempdir/foo/modules/git1/b && echo "not ok 6") || echo "ok 6"
 (cat $tempdir/foo/modules/git1.2/b && echo "ok 7") || echo "not ok 7"
-
-(perl $pmbp --root-dir-name $tempdir/foo --add-git-submodule-recursively aa/m\ $tempdir/git1 && echo "ok 8") || echo "not ok 8"
-(cat $tempdir/foo/aa/m/git1/a && echo "ok 9") || echo "not ok 9"
 
 rm -fr $tempdir

--- a/t/pmbp-git/submodule-add-r-3-parent-dir.t
+++ b/t/pmbp-git/submodule-add-r-3-parent-dir.t
@@ -1,11 +1,8 @@
 #!/bin/sh
-echo "1..4"
+echo "1..16"
 basedir=$(cd `dirname $0`/../.. && pwd)
 pmbp=$basedir/bin/pmbp.pl
 tempdir=`perl -MFile::Temp=tempdir -e 'print tempdir'`/testapp
-
-mkdir -p $tempdir/foo
-cd $tempdir/foo && git init
 
 mkdir -p $tempdir/git1
 cd $tempdir/git1 && git init && touch a && git add a && git commit -m new
@@ -13,8 +10,52 @@ cd $tempdir/git1 && git init && touch a && git add a && git commit -m new
 mkdir -p $tempdir/git2
 cd $tempdir/git2 && git init && touch b && git add b && git submodule add $tempdir/git1 modules/git1 && git commit -m new
 
+# Test case 1 : new Git module should be installed into specified container directory
+
+mkdir -p $tempdir/foo
+cd $tempdir/foo && git init
+
 (perl $pmbp --root-dir-name $tempdir/foo --add-git-submodule-recursively "t_deps/modules $tempdir/git2" && echo "ok 1") || echo "not ok 1"
-(cat $tempdir/foo/t_deps/modules/git1/a && echo "ok 2") || echo "not ok 2"
+([ -f "$tempdir/foo/t_deps/modules/git1/a" ] && echo "ok 2") || echo "not ok 2"
+([ -f "$tempdir/foo/t_deps/modules/git2/b" ] && echo "ok 3") || echo "not ok 3"
+
+rm -fr $tempdir/foo
+
+# Test case 2 : in case that specified Git module is already installed in "modules" directory,
+#   new Git module shouldn't be installed in specified container directory
+
+mkdir -p $tempdir/foo
+cd $tempdir/foo && git init
+
+(perl $pmbp --root-dir-name $tempdir/foo --add-git-submodule-recursively $tempdir/git2 && echo "ok 4") || echo "not ok 4"
+(perl $pmbp --root-dir-name $tempdir/foo --add-git-submodule-recursively "t_deps/modules $tempdir/git2" && echo "ok 5") || echo "not ok 5"
+([ -f "$tempdir/foo/modules/git1/a" ] && echo "ok 6") || echo "not ok 6"
+([ -f "$tempdir/foo/modules/git2/b" ] && echo "ok 7") || echo "not ok 7"
+([ ! -d "$tempdir/foo/t_deps" ] && echo "ok 8") || echo "not ok 8"
+
+rm -fr $tempdir/foo
+
+# Test case 3 : in case that submodule of specified Git module is already installed in "modules" directory,
+#   new Git module should be installed in specified container directory but its submodule shouldn't
+
+mkdir -p $tempdir/foo
+cd $tempdir/foo && git init
+
+(perl $pmbp --root-dir-name $tempdir/foo --add-git-submodule-recursively $tempdir/git1 && echo "ok 9") || echo "not ok 9"
+(perl $pmbp --root-dir-name $tempdir/foo --add-git-submodule-recursively "t_deps/modules $tempdir/git2" && echo "ok 10") || echo "not ok 10"
+([ -f "$tempdir/foo/modules/git1/a" ] && echo "ok 11") || echo "not ok 11"
+([ -f "$tempdir/foo/t_deps/modules/git2/b" ] && echo "ok 12") || echo "not ok 12"
+([ ! -d "$tempdir/foo/t_deps/modules/git1" ] && echo "ok 13") || echo "not ok 13"
+
+rm -fr $tempdir/foo
+
+# Test case 4 : after new submodule is added into installed submodule,
+#   `--add-git-submodule-recursively` should install newly added submodule
+
+mkdir -p $tempdir/foo
+cd $tempdir/foo && git init
+
+(perl $pmbp --root-dir-name $tempdir/foo --add-git-submodule-recursively "t_deps/modules $tempdir/git2" && echo "ok 14") || echo "not ok 14"
 
 mkdir -p $tempdir/git3
 cd $tempdir/git3 && git init && touch c && git add c && git commit -m new
@@ -22,7 +63,17 @@ cd $tempdir/git3 && git init && touch c && git add c && git commit -m new
 cd $tempdir/git2 && git submodule add $tempdir/git3 modules/git3 && git commit -m new
 
 cd $tempdir/foo/t_deps/modules/git2 && git pull
-(perl $pmbp --root-dir-name $tempdir/foo --add-git-submodule-recursively "t_deps/modules $tempdir/git2" && echo "ok 3") || echo "not ok 3"
-(cat $tempdir/foo/t_deps/modules/git3/c && echo "ok 4") || echo "not ok 4"
+(perl $pmbp --root-dir-name $tempdir/foo --add-git-submodule-recursively "t_deps/modules $tempdir/git2" && echo "ok 15") || echo "not ok 15"
+([ -f "$tempdir/foo/t_deps/modules/git3/c" ] && echo "ok 16") || echo "not ok 16"
+
+rm -fr $tempdir/foo
 
 rm -fr $tempdir
+
+# * LICENSE
+#
+# Copyright 2012-2016 Wakaba <wakaba@suikawiki.org>.
+# Copyright 2017 Hatena <https://www.hatena.ne.jp/company/>.
+#
+# This library is free software; you can redistribute it and/or modify
+# it under the same terms as Perl itself.


### PR DESCRIPTION
* `--add-git-submodule`
    * in case that specified submodule is already installed in “modules” directory and specified container directory is not “modules” directory,
        * As-is : specified submodule will be installed into the specified container directory
        * To-be : specified submodule will not be installed into the specified container directory
* `--add-git-submodule-recursively`
    * in case that specified submodule is already installed in “modules” directory and specified container directory is not “modules” directory,
        * As-is : specified submodule will be installed into the specified container directory
        * To-be : specified submodule will not be installed into the specified container directory
    * in case that specified submodule is not installed in “modules” directory yet but one of its descendants is already installed in “modules” directory and specified container directory is not “modules” directory,
        * As-is : that submodule will be installed into the specified container directory
        * To-be : that submodule will not be installed into the specified container directory